### PR TITLE
Add more unit tests for site generation plugins

### DIFF
--- a/src/sitegen/ChildrenList.js
+++ b/src/sitegen/ChildrenList.js
@@ -24,7 +24,7 @@ module.exports = BasePlugin.extend({
 
       _.each(files, function(file) {
          if (file.children) {
-            _.sortBy(file.children, 'title');
+            file.children = _.sortBy(file.children, 'title');
          }
       });
 

--- a/src/sitegen/FileSourceMetadata.js
+++ b/src/sitegen/FileSourceMetadata.js
@@ -7,7 +7,17 @@
 
 var _ = require('underscore'),
     path = require('path'),
-    BasePlugin = require('./BasePlugin');
+    BasePlugin = require('./BasePlugin'),
+    DEFAULT_PARSED_INFO;
+
+DEFAULT_PARSED_INFO = {
+   isWorkspace: false,
+   isBranch: false,
+   isTag: false,
+   isLocal: false,
+   isRemote: false,
+};
+
 
 module.exports = BasePlugin.extend({
 
@@ -23,18 +33,11 @@ module.exports = BasePlugin.extend({
    parseInfoFromPath: function(filePath) {
       var parts = filePath.split(path.sep),
           refType = parts.shift(),
-          info;
+          info = this.defaultParsedInfo();
 
-      info = {
-         isWorkspace: false,
-         isBranch: false,
-         isTag: false,
-         isLocal: false,
-         isRemote: false,
-         paths: {
-            full: filePath,
-            typeDir: refType,
-         },
+      info.paths = {
+         full: filePath,
+         typeDir: refType,
       };
 
       if (refType == this.opts.output.workspaceDir) {
@@ -59,6 +62,10 @@ module.exports = BasePlugin.extend({
       info.paths.docBaseRelative = parts.join(path.sep);
 
       return info;
+   },
+
+   defaultParsedInfo: function() {
+      return _.extend({}, DEFAULT_PARSED_INFO);
    },
 
 });

--- a/src/tests/sitegen/ChildrenListTest.js
+++ b/src/tests/sitegen/ChildrenListTest.js
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2016 Jeremy Thomerson
+ * Licensed under the MIT license.
+ */
+
+'use strict';
+
+var _ = require('underscore'),
+    expect = require('expect.js'),
+    Util = require('./MetalsmithPluginTestingUtility'),
+    util = new Util(),
+    PluginClass = require('../../sitegen/ChildrenList'),
+    plugin = util.createPlugin(PluginClass);
+
+describe('ChildrenList sitegen plugin', function() {
+   // this array intentionally puts children into non-alpha order
+   // so that we also test the order of the children
+   var files = {
+      'workspace/index.md': { title: 'Homepage', __parents: [] },
+      'workspace/SomethingElse.md': { title: 'Something Else', __parents: [ 'workspace/index.md' ] },
+      'workspace/SomethingElse2.md': { title: 'Another Page', __parents: [ 'workspace/index.md' ] },
+      'workspace/Developers.md': { title: 'Dev Team', __parents: [ 'workspace/index.md' ] },
+      'workspace/CodeStandards.md': { title: 'Code Standards', __parents: [ 'workspace/index.md', 'workspace/Developers.md' ] },
+   };
+
+   _.each(files, function(file, name) {
+      file.__name = name;
+      file.parents = _.map(file.__parents, function(parentName) {
+         return files[parentName];
+      });
+   });
+
+   it('basically works', function() {
+      util.run(plugin, files);
+
+      expect(_.pluck(files['workspace/index.md'].children, '__name')).to.eql([
+         'workspace/SomethingElse2.md',
+         'workspace/Developers.md',
+         'workspace/SomethingElse.md',
+      ]);
+
+      expect(_.pluck(files['workspace/Developers.md'].children, '__name')).to.eql([
+         'workspace/CodeStandards.md',
+      ]);
+   });
+});

--- a/src/tests/sitegen/CopyAssetsTest.js
+++ b/src/tests/sitegen/CopyAssetsTest.js
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2016 Jeremy Thomerson
+ * Licensed under the MIT license.
+ */
+
+'use strict';
+
+var _ = require('underscore'),
+    expect = require('expect.js'),
+    Util = require('./MetalsmithPluginTestingUtility'),
+    util = new Util(),
+    PluginClass = require('../../sitegen/CopyAssets'),
+    plugin = util.createPlugin(PluginClass);
+
+describe('CopyAssets sitegen plugin', function() {
+   it('basically works', function() {
+      var files = {
+         'workspace/test.jpg': {},
+         'workspace/something.css': {},
+         'workspace/index.md': {},
+         'workspace/SomeDocumentationPage.md': {},
+      };
+
+      // TODO: implement this test, which will involve mocking grunt (and maybe metalsmith)
+      // util.run(plugin, files);
+      // then test that the jpg and css file were copied, and the md files were not
+      // also test that mkdir was called with the proper input
+   });
+});

--- a/src/tests/sitegen/FileSourceMetadataTest.js
+++ b/src/tests/sitegen/FileSourceMetadataTest.js
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2016 Jeremy Thomerson
+ * Licensed under the MIT license.
+ */
+
+'use strict';
+
+var _ = require('underscore'),
+    expect = require('expect.js'),
+    Util = require('./MetalsmithPluginTestingUtility'),
+    util = new Util(),
+    PluginClass = require('../../sitegen/FileSourceMetadata'),
+    plugin = util.createPlugin(PluginClass),
+    DEFAULT = plugin.defaultParsedInfo();
+
+describe('FileSourceMetadata sitegen plugin', function() {
+
+   describe('defaultParsedInfo', function() {
+      it('does not allow defaults to be overwritten', function() {
+         var before = JSON.parse(JSON.stringify(plugin.defaultParsedInfo())),
+             defaults = plugin.defaultParsedInfo();
+
+         defaults.isWorkspace = true;
+         defaults.paths = {
+            full: 'test',
+         };
+
+         expect(defaults).to.not.eql(before);
+      });
+   });
+
+   describe('parseInfoFromPath', function() {
+      it('basically works', function() {
+         _.each(createTestCases(), function(expectedInfo, name) {
+            expect(plugin.parseInfoFromPath(name)).to.eql(_.extend({}, DEFAULT, expectedInfo));
+         });
+      });
+   });
+
+   it('basically works', function() {
+      var tests = createTestCases(),
+          files = {};
+
+      _.each(tests, function(expectedInfo, name) {
+         files[name] = {};
+      });
+
+      util.run(plugin, files);
+
+      _.each(files, function(file, name) {
+         expect(file.sourceInfo).to.eql(_.extend({}, DEFAULT, tests[name]));
+      });
+   });
+});
+
+function createTestCases() {
+   var tests = {};
+
+   tests['workspace/index.md'] = {
+      isWorkspace: true,
+      branchShorthand: 'workspace',
+      paths: {
+         docBaseRelative: 'index.md',
+         typeDir: 'workspace',
+      }
+   };
+
+   tests['remote-branches/origin/master/index.md'] = {
+      isBranch: true,
+      isRemote: true,
+      paths: {
+         docBaseRelative: 'index.md',
+         typeDir: 'remote-branches',
+         remoteName: 'origin',
+         branchName: 'master',
+      },
+      branchShorthand: 'origin/master',
+   };
+
+   tests['local-branches/master/index.md'] = {
+      isBranch: true,
+      isLocal: true,
+      paths: {
+         docBaseRelative: 'index.md',
+         typeDir: 'local-branches',
+         branchName: 'master',
+      },
+      branchShorthand: 'master',
+   };
+
+   tests['tags/some-tag/index.md'] = {
+      isTag: true,
+      paths: {
+         docBaseRelative: 'index.md',
+         typeDir: 'tags',
+         tagName: 'some-tag',
+      },
+   };
+
+   // same tests, but now with subdirectories
+   tests['workspace/some/folders/a/b/c/index.md'] = {
+      isWorkspace: true,
+      branchShorthand: 'workspace',
+      paths: {
+         docBaseRelative: 'some/folders/a/b/c/index.md',
+         typeDir: 'workspace',
+      }
+   };
+
+   tests['remote-branches/origin/master/some/folders/a/b/c/index.md'] = {
+      isBranch: true,
+      isRemote: true,
+      paths: {
+         docBaseRelative: 'some/folders/a/b/c/index.md',
+         typeDir: 'remote-branches',
+         remoteName: 'origin',
+         branchName: 'master',
+      },
+      branchShorthand: 'origin/master',
+   };
+
+   tests['local-branches/master/some/folders/a/b/c/index.md'] = {
+      isBranch: true,
+      isLocal: true,
+      paths: {
+         docBaseRelative: 'some/folders/a/b/c/index.md',
+         typeDir: 'local-branches',
+         branchName: 'master',
+      },
+      branchShorthand: 'master',
+   };
+
+   tests['tags/some-tag/some/folders/a/b/c/index.md'] = {
+      isTag: true,
+      paths: {
+         docBaseRelative: 'some/folders/a/b/c/index.md',
+         typeDir: 'tags',
+         tagName: 'some-tag',
+      },
+   };
+
+   _.each(tests, function(info, name) {
+      info.paths.full = name;
+   });
+
+   return tests;
+}

--- a/src/tests/sitegen/HeadingsMapTest.js
+++ b/src/tests/sitegen/HeadingsMapTest.js
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2016 Jeremy Thomerson
+ * Licensed under the MIT license.
+ */
+
+'use strict';
+
+var _ = require('underscore'),
+    Q = require('q'),
+    fs = require('fs'),
+    path = require('path'),
+    expect = require('expect.js'),
+    Util = require('./MetalsmithPluginTestingUtility'),
+    util = new Util(),
+    PluginClass = require('../../sitegen/HeadingsMap'),
+    plugin = util.createPlugin(PluginClass);
+
+describe('HeadingsMap sitegen plugin', function() {
+   it('basically works', function(done) {
+      var loadFiles;
+
+      loadFiles = _.map([ 'index.html', 'SomeOtherDocPage.html' ], function(filename) {
+         return Q.nfcall(fs.readFile, path.join(__dirname, 'fixtures', filename))
+            .then(function(markup) {
+               return [ filename, markup ];
+            });
+      });
+
+      Q.all(loadFiles)
+         .then(function(loadedFiles) {
+            return _.chain(loadedFiles)
+               .object()
+               .mapObject(function(contents) {
+                  return { contents: contents };
+               })
+               .value();
+         })
+         .then(function(files) {
+            util.run(plugin, files);
+
+            expect(files['index.html'].headings).to.eql([
+               { id: 'welcome-to-documentation', text: 'Welcome to Documentation', weight: 1, subheadings: [
+                  { id: 'second-level-subheading', text: 'Second-Level Subheading', weight: 2, subheadings: [
+                     { id: 'third-level-subheading', text: 'Third-Level Subheading', weight: 3, subheadings: [] },
+                  ]},
+               ]},
+            ]);
+
+            expect(files['SomeOtherDocPage.html'].headings).to.eql([
+               { id: 'another-page-of-docs', text: 'Another Page of Docs', weight: 1, subheadings: [
+                  { id: 'lots-of-markdown-things', text: 'Lots of Markdown Things', weight: 2, subheadings: [
+                     { id: 'code-links', text: 'Code links', weight: 3, subheadings: [] },
+                  ]},
+               ]},
+            ]);
+
+            done();
+         })
+         .catch(done);
+   });
+});

--- a/src/tests/sitegen/MetalsmithPluginTestingUtility.js
+++ b/src/tests/sitegen/MetalsmithPluginTestingUtility.js
@@ -35,7 +35,12 @@ module.exports = Class.extend({
    },
 
    run: function(plugin, files) {
-      plugin.run(files, this.mockMetalsmith(), _.noop);
+      var ms = this.mockMetalsmith();
+      plugin.run(files, ms, _.noop);
+
+      return {
+         metalsmith: ms,
+      }
    },
 
    readFixturePage: function(filename) {

--- a/src/tests/sitegen/ParentsListTest.js
+++ b/src/tests/sitegen/ParentsListTest.js
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2016 Jeremy Thomerson
+ * Licensed under the MIT license.
+ */
+
+'use strict';
+
+var _ = require('underscore'),
+    path = require('path'),
+    expect = require('expect.js'),
+    Util = require('./MetalsmithPluginTestingUtility'),
+    util = new Util(),
+    PluginClass = require('../../sitegen/ParentsList'),
+    plugin = util.createPlugin(PluginClass);
+
+function testFilesAgainstExpectations(file, name) {
+   expect(_.pluck(file.parents, '__name')).to.eql(file.__expectedParents);
+}
+
+describe('ParentsList sitegen plugin', function() {
+
+   it('basically works', function() {
+      var files = getSampleFiles(),
+          names = _.keys(files);
+
+      util.run(plugin, files);
+
+      expect(_.keys(files)).to.eql(names);
+      _.each(files, testFilesAgainstExpectations);
+   });
+
+   it('works when the parent is a non-existent file', function() {
+      var files = getSampleFiles();
+
+      addSampleFile(files, 'workspace/SomeFile.md', 'workspace', [ 'workspace/index.md' ], 'NonExistentPage');
+      util.run(plugin, files);
+      _.each(files, testFilesAgainstExpectations);
+   });
+
+});
+
+function addSampleFile(files, name, branchShorthand, expectedParents, parentSlug) {
+   files[name] = {
+      __name: name,
+      __expectedParents: expectedParents,
+
+      sourceInfo: { branchShorthand: branchShorthand },
+      slug: path.basename(name).replace(/\.md$/, ''),
+      parent: parentSlug,
+   };
+}
+
+function getSampleFiles() {
+   var files = {};
+
+   // root file in your workspace
+   addSampleFile(
+      files,
+      'workspace/index.md',
+      'workspace',
+      []
+   );
+   // a file that sets no parent, but should be child of root
+   addSampleFile(
+      files,
+      'workspace/Developers.md',
+      'workspace',
+      [ 'workspace/index.md' ]
+   );
+   // a file that sets a parent and is grandchild of root
+   addSampleFile(
+      files,
+      'workspace/dev-team/DevelopersCodingStandards.md',
+      'workspace',
+      [ 'workspace/index.md', 'workspace/Developers.md' ],
+      'Developers'
+   );
+   // a file that sets a parent and is great-grandchild of root
+   addSampleFile(
+      files,
+      'workspace/dev-team/a/b/StandardsJS.md',
+      'workspace',
+      [ 'workspace/index.md', 'workspace/Developers.md', 'workspace/dev-team/DevelopersCodingStandards.md' ],
+      'DevelopersCodingStandards'
+   );
+
+   // all the same tests, but with a local branch:
+   // root file in your workspace
+   addSampleFile(
+      files,
+      'local-branches/master/index.md',
+      'master',
+      []
+   );
+   // a file that sets no parent, but should be child of root
+   addSampleFile(
+      files,
+      'local-branches/master/Developers.md',
+      'master',
+      [ 'local-branches/master/index.md' ]
+   );
+   // a file that sets a parent and is grandchild of root
+   addSampleFile(
+      files,
+      'local-branches/master/dev-team/DevelopersCodingStandards.md',
+      'master',
+      [ 'local-branches/master/index.md', 'local-branches/master/Developers.md' ],
+      'Developers'
+   );
+   // a file that sets a parent and is great-grandchild of root
+   addSampleFile(
+      files,
+      'local-branches/master/dev-team/a/b/StandardsJS.md',
+      'master',
+      [ 'local-branches/master/index.md', 'local-branches/master/Developers.md', 'local-branches/master/dev-team/DevelopersCodingStandards.md' ],
+      'DevelopersCodingStandards'
+   );
+
+   // all the same tests, but with a remote branch:
+   // root file in your workspace
+   addSampleFile(
+      files,
+      'remotes/origin/master/index.md',
+      'origin/master',
+      []
+   );
+   // a file that sets no parent, but should be child of root
+   addSampleFile(
+      files,
+      'remotes/origin/master/Developers.md',
+      'origin/master',
+      [ 'remotes/origin/master/index.md' ]
+   );
+   // a file that sets a parent and is grandchild of root
+   addSampleFile(
+      files,
+      'remotes/origin/master/dev-team/DevelopersCodingStandards.md',
+      'origin/master',
+      [ 'remotes/origin/master/index.md', 'remotes/origin/master/Developers.md' ],
+      'Developers'
+   );
+   // a file that sets a parent and is great-grandchild of root
+   addSampleFile(
+      files,
+      'remotes/origin/master/dev-team/a/b/StandardsJS.md',
+      'origin/master',
+      [ 'remotes/origin/master/index.md', 'remotes/origin/master/Developers.md', 'remotes/origin/master/dev-team/DevelopersCodingStandards.md' ],
+      'DevelopersCodingStandards'
+   );
+
+   return files;
+}

--- a/src/tests/sitegen/SetGlobalBranchListTest.js
+++ b/src/tests/sitegen/SetGlobalBranchListTest.js
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2016 Jeremy Thomerson
+ * Licensed under the MIT license.
+ */
+
+'use strict';
+
+var _ = require('underscore'),
+    expect = require('expect.js'),
+    Util = require('./MetalsmithPluginTestingUtility'),
+    util = new Util(),
+    PluginClass = require('../../sitegen/SetGlobalBranchList'),
+    plugin = util.createPlugin(PluginClass),
+    parser = util.createPlugin(require('../../sitegen/FileSourceMetadata')),
+    DEFAULT = parser.defaultParsedInfo();
+
+describe('SetGlobalBranchList sitegen plugin', function() {
+   it('basically works', function() {
+      var files, runResults, expectations;
+
+      files = {
+         'workspace/index.md': { },
+         'workspace/SomeDocumentationPage.md': { },
+         'workspace/folder/SomeDocumentationPage.md': { },
+         'local-branches/master/folder/SomeDocumentationPage.md': { },
+         'remote-branches/origin/master/folder/SomeDocumentationPage.md': { },
+      };
+
+      expectations = [
+         {
+            isWorkspace: true,
+            branchShorthand: 'workspace',
+         },
+         {
+            isBranch: true,
+            isLocal: true,
+            branchShorthand: 'master',
+         },
+         {
+            isBranch: true,
+            isRemote: true,
+            branchShorthand: 'origin/master',
+         },
+      ];
+
+      expectations = _.reduce(expectations, function(memo, exp) {
+         memo[exp.branchShorthand] = _.extend({}, DEFAULT, exp);
+         return memo;
+      }, {});
+
+      // use this to set up the correct info on the files:
+      util.run(parser, files);
+
+      // now run the plugin that we're testing
+      runResults = util.run(plugin, files);
+
+      console.log(runResults.metalsmith.metadata());
+      expect(runResults.metalsmith.metadata()).to.eql({ branches: expectations });
+   });
+});

--- a/src/tests/sitegen/TemplatingTest.js
+++ b/src/tests/sitegen/TemplatingTest.js
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2016 Jeremy Thomerson
+ * Licensed under the MIT license.
+ */
+
+'use strict';
+
+var _ = require('underscore'),
+    expect = require('expect.js'),
+    Util = require('./MetalsmithPluginTestingUtility'),
+    util = new Util(),
+    PluginClass = require('../../sitegen/Templating'),
+    plugin = util.createPlugin(PluginClass);
+
+describe('Templating sitegen plugin', function() {
+
+   // TODO: consider if there a way to test the actual templating without tight coupling
+
+   describe('template utility', function() {
+
+      describe('path function', function() {
+
+         it('basically works', function() {
+            var templateUtil = plugin._createTemplateUtility({ url: 'workspace/a/b/c/index.html' });
+
+            expect(templateUtil.path('css/bootstrap.min.css')).to.eql('../../../../css/bootstrap.min.css');
+            expect(templateUtil.path('workspace/a/b/c/OtherPage.html')).to.eql('OtherPage.html');
+            expect(templateUtil.path('workspace/a/OtherFolderPage.html')).to.eql('../../OtherFolderPage.html');
+         });
+
+         it('works with slashes in either or both URLs', function() {
+            var templateUtil = plugin._createTemplateUtility({ url: 'workspace/a/b/c/index.html' });
+
+            // slash only in toURL
+            expect(templateUtil.path('/css/bootstrap.min.css')).to.eql('../../../../css/bootstrap.min.css');
+            expect(templateUtil.path('/workspace/a/b/c/OtherPage.html')).to.eql('OtherPage.html');
+            expect(templateUtil.path('/workspace/a/OtherFolderPage.html')).to.eql('../../OtherFolderPage.html');
+
+            // slash in utility file URL (src)
+            templateUtil = plugin._createTemplateUtility({ url: '/workspace/a/b/c/index.html' });
+
+            // and not in toURL
+            expect(templateUtil.path('css/bootstrap.min.css')).to.eql('../../../../css/bootstrap.min.css');
+            expect(templateUtil.path('workspace/a/b/c/OtherPage.html')).to.eql('OtherPage.html');
+            expect(templateUtil.path('workspace/a/OtherFolderPage.html')).to.eql('../../OtherFolderPage.html');
+
+            // and in toURL
+            expect(templateUtil.path('/css/bootstrap.min.css')).to.eql('../../../../css/bootstrap.min.css');
+            expect(templateUtil.path('/workspace/a/b/c/OtherPage.html')).to.eql('OtherPage.html');
+            expect(templateUtil.path('/workspace/a/OtherFolderPage.html')).to.eql('../../OtherFolderPage.html');
+         });
+
+      });
+   });
+});

--- a/src/tests/sitegen/TitleFallbacksTest.js
+++ b/src/tests/sitegen/TitleFallbacksTest.js
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2016 Jeremy Thomerson
+ * Licensed under the MIT license.
+ */
+
+'use strict';
+
+var _ = require('underscore'),
+    expect = require('expect.js'),
+    Util = require('./MetalsmithPluginTestingUtility'),
+    util = new Util(),
+    PluginClass = require('../../sitegen/TitleFallbacks'),
+    plugin = util.createPlugin(PluginClass);
+
+describe('TitleFallbacks sitegen plugin', function() {
+   it('basically works', function() {
+      var files = {};
+
+      files['workspace/index.md'] = {
+         title: 'this is my user-defined YAML frontmatter title',
+         contents: new Buffer('Some markup, and an <h1>HTML Title</h1> in this one'),
+         slug: 'index',
+         expectedTitle: 'this is my user-defined YAML frontmatter title',
+      };
+
+      files['workspace/SomeDocumentationPage.md'] = {
+         // NOTE: spaces intentionally entered around the HTML title
+         contents: new Buffer('Some markup, and an <h1> HTML Title </h1> in this one'),
+         slug: 'SomeDocumentationPage',
+         expectedTitle: 'HTML Title',
+      };
+
+      files['workspace/SomeOtherDocumentationPage.md'] = {
+         contents: new Buffer('Some markup, and no h1 title in this one'),
+         slug: 'SomeOtherDocumentationPage',
+         expectedTitle: 'Some Other Documentation Page',
+      };
+
+      util.run(plugin, files);
+
+      _.each(files, function(file, name) {
+         expect(file.title).to.eql(file.expectedTitle);
+      });
+   });
+});


### PR DESCRIPTION
This adds unit tests for nearly every site generation plugin currently in use (that didn't already have tests). There are a couple of exceptions:
- Debug: not really needed
- CopyAssets: a test created, but not implemented - needs mocked grunt, etc, as noted in TODO
