### PR TITLE
Change node versions we test with on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,8 @@
 language: node_js
 node_js:
-  - "stable"
   - "5"
-  - "5.1"
   - "4"
-  - "4.2"
-  - "4.1"
-  - "4.0"
+  - "4.4.4"
 
 # Not compatible with older versions because some dependencies
 # use yield/unyield, etc


### PR DESCRIPTION
At this time stable (6.2) is failing because of some dependency that apparently
has an issue with the architecture of the system that travis is running the
build on. Not clear at this time, but also not super important to me. We are
standardizing on 4.4.4 for all silvermine projects currently, so we'll test
that as well as 4 and 5 latest.
